### PR TITLE
Fix ListOfStringsArgument.ResetDefaultValue to replace instead of append (#17)

### DIFF
--- a/arguments/arg_list_of_strings.go
+++ b/arguments/arg_list_of_strings.go
@@ -67,7 +67,7 @@ func (arg ListOfStringsArgument) GetDefaultValue() any {
 
 // ResetDefaultValue resets the value of the argument to the default value.
 func (arg *ListOfStringsArgument) ResetDefaultValue() {
-	*(arg.Value) = append(*(arg.Value), arg.DefaultValue...)
+	*(arg.Value) = append([]string{}, arg.DefaultValue...)
 }
 
 // IsRequired returns whether the argument is required.

--- a/arguments/arg_list_of_strings_test.go
+++ b/arguments/arg_list_of_strings_test.go
@@ -94,6 +94,27 @@ func TestListOfStringsArgument_Consume_NoMatch(t *testing.T) {
 	}
 }
 
+func TestListOfStringsArgument_ResetDefaultValue_Idempotent(t *testing.T) {
+	values := []string{}
+	arg := ListOfStringsArgument{}
+	arg.Init(&values, "", "list", []string{"a", "b"}, false, "help")
+
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []string{"a", "b"}) {
+		t.Fatalf("after first reset expected [a b], got %v", *arg.Value)
+	}
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []string{"a", "b"}) {
+		t.Fatalf("after second reset expected [a b], got %v", *arg.Value)
+	}
+
+	*arg.Value = append(*arg.Value, "user")
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []string{"a", "b"}) {
+		t.Fatalf("reset should discard user values, got %v", *arg.Value)
+	}
+}
+
 func TestListOfStringsArgument_Getters(t *testing.T) {
 	values := []string{"item1", "item2"}
 	arg := ListOfStringsArgument{


### PR DESCRIPTION
### Linked Issue
Closes #17

### Root Cause
`ResetDefaultValue` was implemented as `*(arg.Value) = append(*(arg.Value), arg.DefaultValue...)`. `append` extends the existing slice; nothing clears it first. The method therefore never reset the argument — it repeatedly concatenated the defaults onto whatever was already stored.

### Fix Description
Assign a fresh slice containing exactly the defaults: `*(arg.Value) = append([]string{}, arg.DefaultValue...)`. This overwrites the contents rather than appending to them, and produces an independent backing array so subsequent mutations of the value do not alias the defaults.

### How Verified
- **Tests:** added `TestListOfStringsArgument_ResetDefaultValue_Idempotent` which calls `ResetDefaultValue` twice consecutively, then appends a user value, then resets again. The test fails on the old implementation (`[a b a b]` after the second reset) and passes on the new one.
- Ran `go test ./arguments/...` — all existing tests pass.

### Test Coverage
- **Added:** `arguments/arg_list_of_strings_test.go::TestListOfStringsArgument_ResetDefaultValue_Idempotent`.

### Scope of Change
- **Files changed:** `arguments/arg_list_of_strings.go`, `arguments/arg_list_of_strings_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very small, local change. The new behaviour matches the documented "resets the value ... to the default value" contract and fixes observable state leakage between parses; callers that relied on the accumulation behaviour were relying on a bug.