### PR TITLE
Fix ListOfIntsArgument.ResetDefaultValue to replace instead of append (#18)

### DIFF
--- a/arguments/arg_list_of_integers.go
+++ b/arguments/arg_list_of_integers.go
@@ -71,7 +71,7 @@ func (arg ListOfIntsArgument) GetDefaultValue() any {
 
 // ResetDefaultValue resets the value of the argument to the default value.
 func (arg *ListOfIntsArgument) ResetDefaultValue() {
-	*(arg.Value) = append(*(arg.Value), arg.DefaultValue...)
+	*(arg.Value) = append([]int{}, arg.DefaultValue...)
 }
 
 // IsRequired returns whether the argument is required.

--- a/arguments/arg_list_of_integers_test.go
+++ b/arguments/arg_list_of_integers_test.go
@@ -94,6 +94,27 @@ func TestListOfIntsArgument_Consume_NoMatch(t *testing.T) {
 	}
 }
 
+func TestListOfIntsArgument_ResetDefaultValue_Idempotent(t *testing.T) {
+	values := []int{}
+	arg := ListOfIntsArgument{}
+	arg.Init(&values, "", "list", []int{1, 2}, false, "help")
+
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []int{1, 2}) {
+		t.Fatalf("after first reset expected [1 2], got %v", *arg.Value)
+	}
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []int{1, 2}) {
+		t.Fatalf("after second reset expected [1 2], got %v", *arg.Value)
+	}
+
+	*arg.Value = append(*arg.Value, 99)
+	arg.ResetDefaultValue()
+	if !slices.Equal(*arg.Value, []int{1, 2}) {
+		t.Fatalf("reset should discard user values, got %v", *arg.Value)
+	}
+}
+
 func TestListOfIntsArgument_Getters(t *testing.T) {
 	values := []int{7, 14}
 	arg := ListOfIntsArgument{


### PR DESCRIPTION
### Linked Issue
Closes #18

### Root Cause
`ResetDefaultValue` was `*(arg.Value) = append(*(arg.Value), arg.DefaultValue...)`. `append` extends the existing slice; the method never actually reset it — it repeatedly concatenated the defaults onto whatever was already stored.

### Fix Description
Assign a fresh slice containing exactly the defaults: `*(arg.Value) = append([]int{}, arg.DefaultValue...)`. This overwrites the previous contents and produces a backing array that is independent from `DefaultValue`, so later mutations of the value do not alias the defaults.

### How Verified
- **Tests:** added `TestListOfIntsArgument_ResetDefaultValue_Idempotent` that calls `ResetDefaultValue` twice, then mutates the value, then resets again. Fails on the old implementation (`[1 2 1 2]` after the second reset) and passes on the new one.
- Ran `go test ./arguments/...` — all existing tests still pass.

### Test Coverage
- **Added:** `arguments/arg_list_of_integers_test.go::TestListOfIntsArgument_ResetDefaultValue_Idempotent`.

### Scope of Change
- **Files changed:** `arguments/arg_list_of_integers.go`, `arguments/arg_list_of_integers_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very small, local change that aligns behaviour with the documented contract. Callers that relied on the accumulation behaviour were relying on a bug.