### PR TITLE
Fix MapOfHttpHeadersArgument.ResetDefaultValue to discard previous keys (#19)

### DIFF
--- a/arguments/arg_map_of_http_headers.go
+++ b/arguments/arg_map_of_http_headers.go
@@ -71,12 +71,11 @@ func (arg *MapOfHttpHeadersArgument) SetValue(value any) {
 
 // ResetDefaultValue resets the value of the argument to the default value.
 func (arg *MapOfHttpHeadersArgument) ResetDefaultValue() {
-	if (*arg.Value) == nil {
-		(*arg.Value) = make(map[string]string, 0)
-	}
+	reset := make(map[string]string, len(arg.DefaultValue))
 	for key, value := range arg.DefaultValue {
-		(*arg.Value)[key] = value
+		reset[key] = value
 	}
+	*arg.Value = reset
 }
 
 // IsRequired returns whether the argument is required.

--- a/arguments/arg_map_of_http_headers_test.go
+++ b/arguments/arg_map_of_http_headers_test.go
@@ -112,3 +112,26 @@ func TestMapOfHttpHeadersArgument_Consume_NoMatch(t *testing.T) {
 		t.Errorf("Expected no headers to be set, got '%v'", value)
 	}
 }
+
+func TestMapOfHttpHeadersArgument_ResetDefaultValue_DiscardsPreviousKeys(t *testing.T) {
+	var value map[string]string
+	arg := MapOfHttpHeadersArgument{}
+	arg.Init(&value, "h", "headers", map[string]string{"Content-Type": "application/json"}, false, "help")
+
+	arg.ResetDefaultValue()
+	if !reflect.DeepEqual(*arg.Value, map[string]string{"Content-Type": "application/json"}) {
+		t.Fatalf("unexpected value after first reset: %v", *arg.Value)
+	}
+
+	if _, err := arg.Consume([]string{"--headers", "X-Extra: 1"}); err != nil {
+		t.Fatalf("consume failed: %v", err)
+	}
+
+	arg.ResetDefaultValue()
+	if _, leaked := (*arg.Value)["X-Extra"]; leaked {
+		t.Fatalf("reset should discard previously-set keys, got %v", *arg.Value)
+	}
+	if !reflect.DeepEqual(*arg.Value, map[string]string{"Content-Type": "application/json"}) {
+		t.Fatalf("unexpected value after reset: %v", *arg.Value)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #19

### Root Cause
The old implementation re-used the existing map and only copied the defaults into it:

```go
if (*arg.Value) == nil {
    (*arg.Value) = make(map[string]string, 0)
}
for key, value := range arg.DefaultValue {
    (*arg.Value)[key] = value
}
```

Any key not also present in `DefaultValue` stayed in the map. The method's name and documentation promise a reset, but the behaviour was a merge.

### Fix Description
Allocate a fresh map populated from `DefaultValue` and assign it through the pointer. This guarantees that after the call the map contains exactly the default entries, drops any previously-consumed headers, and makes the value independent of the `DefaultValue` map (so later mutations don't leak back into the defaults).

### How Verified
- **Tests:** added `TestMapOfHttpHeadersArgument_ResetDefaultValue_DiscardsPreviousKeys` which consumes a header then calls reset and asserts the extra key is gone. Fails on the old implementation and passes on the new one.
- Ran `go test ./arguments/...` — all existing tests still pass.

### Test Coverage
- **Added:** `arguments/arg_map_of_http_headers_test.go::TestMapOfHttpHeadersArgument_ResetDefaultValue_DiscardsPreviousKeys`.

### Scope of Change
- **Files changed:** `arguments/arg_map_of_http_headers.go`, `arguments/arg_map_of_http_headers_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Small and local. The new behaviour matches the "reset to default" contract; the previous merge behaviour was a defect, not a documented feature.