### PR TITLE
Fix populateMaps duplicate registration and cross-call accumulation (#20)

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -28,55 +28,35 @@ import (
 //	This method should be called before parsing command-line arguments to ensure that all arguments
 //	are correctly registered and accessible for lookup during the parsing process.
 func (ap *ArgumentsParser) populateMaps() {
-	// Create the maps even if they already exist
+	// Reset lookup maps and per-parse slices so repeated calls stay consistent
 	ap.shortNameToArgument = make(map[string]arguments.Argument)
 	ap.longNameToArgument = make(map[string]arguments.Argument)
+	ap.requiredArguments = ap.requiredArguments[:0]
+	ap.allArguments = ap.allArguments[:0]
 
 	if ap.Groups == nil {
 		ap.Groups = make(map[string]*argumentgroup.ArgumentGroup)
 	}
 
-	// Register arguments from the default group
-	if ap.Groups[""] != nil {
-		for _, arg := range ap.Groups[""].Arguments {
+	// Ensure the default group exists so downstream code can rely on it
+	if ap.Groups[""] == nil {
+		ap.Groups[""] = &argumentgroup.ArgumentGroup{}
+	}
+
+	// Register arguments from every group exactly once (the default group is keyed by "")
+	for _, group := range ap.Groups {
+		for _, arg := range group.Arguments {
 			if shortName := arg.GetShortName(); shortName != "" {
 				ap.shortNameToArgument[shortName] = arg
 			}
 			if longName := arg.GetLongName(); longName != "" {
 				ap.longNameToArgument[longName] = arg
 			}
-			//
 			if arg.IsRequired() {
 				ap.requiredArguments = append(ap.requiredArguments, arg)
 			}
 			ap.allArguments = append(ap.allArguments, arg)
 		}
-	} else {
-		// Not initialized, we init it for the first time
-		ag := argumentgroup.ArgumentGroup{}
-		ap.Groups[""] = &ag
-	}
-
-	// Register arguments from all sub groups
-	if ap.Groups != nil {
-		for _, group := range ap.Groups {
-			for _, arg := range group.Arguments {
-				if shortName := arg.GetShortName(); shortName != "" {
-					ap.shortNameToArgument[shortName] = arg
-				}
-				if longName := arg.GetLongName(); longName != "" {
-					ap.longNameToArgument[longName] = arg
-				}
-				//
-				if arg.IsRequired() {
-					ap.requiredArguments = append(ap.requiredArguments, arg)
-				}
-				ap.allArguments = append(ap.allArguments, arg)
-			}
-		}
-	} else {
-		// Not initialized, we init it for the first time
-		ap.Groups = make(map[string]*argumentgroup.ArgumentGroup)
 	}
 
 	if ap.ParsingState.ParsedArguments.PositionalArguments == nil {

--- a/parser/populate_maps_test.go
+++ b/parser/populate_maps_test.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestPopulateMaps_DefaultGroupRegisteredOnce(t *testing.T) {
+	ap := NewParser("t")
+
+	var a, b int
+	if err := ap.NewIntArgument(&a, "a", "aaa", 0, true, "h"); err != nil {
+		t.Fatalf("NewIntArgument(a) failed: %v", err)
+	}
+	if err := ap.NewIntArgument(&b, "", "bbb", 0, false, "h"); err != nil {
+		t.Fatalf("NewIntArgument(b) failed: %v", err)
+	}
+
+	ap.populateMaps()
+
+	if got := len(ap.allArguments); got != 2 {
+		t.Fatalf("expected 2 arguments in allArguments, got %d", got)
+	}
+	if got := len(ap.requiredArguments); got != 1 {
+		t.Fatalf("expected 1 argument in requiredArguments, got %d", got)
+	}
+
+	// Calling populateMaps again must not grow the slices.
+	ap.populateMaps()
+	ap.populateMaps()
+
+	if got := len(ap.allArguments); got != 2 {
+		t.Fatalf("expected 2 arguments in allArguments after repeated calls, got %d", got)
+	}
+	if got := len(ap.requiredArguments); got != 1 {
+		t.Fatalf("expected 1 argument in requiredArguments after repeated calls, got %d", got)
+	}
+}
+
+func TestPopulateMaps_MixedGroupsCountedOnce(t *testing.T) {
+	ap := NewParser("t")
+
+	var a int
+	if err := ap.NewIntArgument(&a, "", "a", 0, true, "h"); err != nil {
+		t.Fatalf("NewIntArgument failed: %v", err)
+	}
+
+	grp, err := ap.NewArgumentGroup("G")
+	if err != nil {
+		t.Fatalf("NewArgumentGroup failed: %v", err)
+	}
+	var b int
+	if err := grp.NewIntArgument(&b, "", "b", 0, true, "h"); err != nil {
+		t.Fatalf("group.NewIntArgument failed: %v", err)
+	}
+
+	ap.populateMaps()
+
+	if got := len(ap.allArguments); got != 2 {
+		t.Fatalf("expected 2 arguments in allArguments, got %d", got)
+	}
+	if got := len(ap.requiredArguments); got != 2 {
+		t.Fatalf("expected 2 required arguments, got %d", got)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #20

### Root Cause
`populateMaps` had two defects in how it built the per-parse argument slices:

1. The default group was iterated twice — once by a dedicated branch for `ap.Groups[""]`, and again by the subsequent `for _, group := range ap.Groups` loop (which already includes the default group). Every default-group argument was therefore pushed into `requiredArguments` and `allArguments` twice per call.
2. The lookup maps (`shortNameToArgument`, `longNameToArgument`) were freshly allocated at the top of the function, but the slices `requiredArguments` and `allArguments` were only ever appended to, so calling `ParseFrom` more than once kept growing them.

The first defect also meant `ResetDefaultValue` ran twice on every default-group argument before parsing — invisible for scalar types, but user-visible for the list types (which compounded with the append-based bug in `ResetDefaultValue` fixed by #23/#24).

### Fix Description
Rewrote the slice/map population into a single pass:

- Reset both slices at the top of the function alongside the maps.
- Drop the redundant default-group branch. The default group (keyed by the empty string) is created on demand if missing and is then registered by the unified loop over `ap.Groups`, just like every other group.

The map order is still non-deterministic across Go runs, but that already was the case for the second loop — no caller depends on the order of `allArguments` / `requiredArguments`; only their contents matter for the required-argument check and for the group-constraint checks that follow.

### How Verified
- **Tests:** added `parser/populate_maps_test.go` with two cases:
  - `TestPopulateMaps_DefaultGroupRegisteredOnce` — registers two default-group args (one required) and asserts `len(allArguments) == 2`, `len(requiredArguments) == 1`, and that calling `populateMaps` repeatedly does not grow either slice. Fails on the old code (counts were `4` and `2` after the first call).
  - `TestPopulateMaps_MixedGroupsCountedOnce` — mixes a default-group arg with a named-group arg and asserts each is counted once.
- Ran `go test ./...` — all existing tests pass.

### Test Coverage
- **Added:** `parser/populate_maps_test.go::TestPopulateMaps_DefaultGroupRegisteredOnce`, `TestPopulateMaps_MixedGroupsCountedOnce`.

### Scope of Change
- **Files changed:** `parser/parse.go`, `parser/populate_maps_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The rewrite only tightens what was already intended — every registered argument appears in the lookup maps and slices exactly once per call — and fixes a defect (duplicate default-group reset) that is only latent when the list-reset bugs are also fixed. Safe to merge independently of the other PRs.