### PR TITLE
Fix case-insensitive subparser lookup in ParseFrom (#21)

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -130,17 +130,17 @@ func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 				ap.UsageFrom(index, parsingState)
 				os.Exit(0)
 			}
-			if asp, exists := ap.SubParsers.Parsers[subparserName]; exists {
+			lookupName := subparserName
+			if ap.SubParsers.CaseInsensitive {
+				lookupName = strings.ToLower(subparserName)
+			}
+			if asp, exists := ap.SubParsers.Parsers[lookupName]; exists {
 				// Set the subparser name value to the pointer
-				*(ap.SubParsers.Value) = subparserName
+				*(ap.SubParsers.Value) = lookupName
 				asp.ParseFrom(index+1, parsingState)
 				return
 			} else {
-				if ap.SubParsers.CaseInsensitive {
-					parsingState.AddErrorMessage(fmt.Sprintf("No subparser with name \"%s\" was found.", strings.ToLower(subparserName)))
-				} else {
-					parsingState.AddErrorMessage(fmt.Sprintf("No subparser with name \"%s\" was found.", subparserName))
-				}
+				parsingState.AddErrorMessage(fmt.Sprintf("No subparser with name \"%s\" was found.", lookupName))
 			}
 		} else {
 			ap.UsageFrom(index, parsingState)

--- a/parser/subparser_case_test.go
+++ b/parser/subparser_case_test.go
@@ -1,0 +1,58 @@
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+func runParseWithArgs(ap *ArgumentsParser, args []string) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = args
+	ap.Parse()
+}
+
+func TestSubparserCaseInsensitiveDispatch(t *testing.T) {
+	ap := NewParser("t")
+	var mode string
+	ap.SetupSubParsing("mode", &mode, true)
+
+	var flag bool
+	sub := ap.AddSubParser("GroupA", "…")
+	if err := sub.NewBoolArgument(&flag, "", "--flag", false, "…"); err != nil {
+		t.Fatalf("NewBoolArgument failed: %v", err)
+	}
+
+	runParseWithArgs(ap, []string{"prog", "GroupA", "--flag"})
+
+	if len(ap.ParsingState.ErrorMessages) != 0 {
+		t.Fatalf("expected no errors, got %v", ap.ParsingState.ErrorMessages)
+	}
+	if mode != "groupa" {
+		t.Fatalf("expected mode=groupa, got %q", mode)
+	}
+	if !flag {
+		t.Fatalf("expected flag=true, got false")
+	}
+}
+
+func TestSubparserCaseSensitiveDispatchUnchanged(t *testing.T) {
+	ap := NewParser("t")
+	var mode string
+	ap.SetupSubParsing("mode", &mode, false)
+
+	var flag bool
+	sub := ap.AddSubParser("GroupA", "…")
+	if err := sub.NewBoolArgument(&flag, "", "--flag", false, "…"); err != nil {
+		t.Fatalf("NewBoolArgument failed: %v", err)
+	}
+
+	runParseWithArgs(ap, []string{"prog", "GroupA", "--flag"})
+
+	if len(ap.ParsingState.ErrorMessages) != 0 {
+		t.Fatalf("expected no errors in case-sensitive mode with exact name, got %v", ap.ParsingState.ErrorMessages)
+	}
+	if mode != "GroupA" {
+		t.Fatalf("expected mode=GroupA, got %q", mode)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #21

### Root Cause
`AddSubParser` stores subparser keys in lowercase when `CaseInsensitive` is set, but `ParseFrom` looked them up with the unmodified user input:

```go
subparserName := parsingState.RawArguments[index]
...
if asp, exists := ap.SubParsers.Parsers[subparserName]; exists { ... }
```

Any non-all-lowercase name therefore missed the map and produced `No subparser with name "…" was found.`. The error-message branch already called `strings.ToLower` on the name, which is what made the defect invisible in textual output but confirmed that only the lookup had been missed.

### Fix Description
Normalise the incoming name once, using the same rule as `AddSubParser`:

```go
lookupName := subparserName
if ap.SubParsers.CaseInsensitive {
    lookupName = strings.ToLower(subparserName)
}
```

and use `lookupName` for both the map lookup and the value stored in `*ap.SubParsers.Value`. Error messages also use `lookupName`, which collapses the two branches that existed before. Case-sensitive dispatch is unchanged (the raw name is used unchanged when `CaseInsensitive` is false).

### How Verified
- **Runtime:** reproduced the defect on current `main` and confirmed the fix against the minimal program in #21. With the fix, `./prog GroupA --flag` sets `mode = "groupa"` and `flag = true` with no error.
- **Tests:** added two cases:
  - `TestSubparserCaseInsensitiveDispatch` — registers subparser `"GroupA"` case-insensitively, parses `GroupA --flag`, asserts no errors, `mode == "groupa"`, `flag == true`. Fails on `main`.
  - `TestSubparserCaseSensitiveDispatchUnchanged` — same inputs with `caseInsensitive = false` to pin the case-sensitive path; `mode == "GroupA"`.
- Ran `go test ./...` — all existing tests pass.

### Test Coverage
- **Added:** `parser/subparser_case_test.go::TestSubparserCaseInsensitiveDispatch`, `TestSubparserCaseSensitiveDispatchUnchanged`.

### Scope of Change
- **Files changed:** `parser/parse.go`, `parser/subparser_case_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The only behavioural change is that case-insensitive subparsers now actually match mixed-case input, which is the documented contract. Case-sensitive dispatch is byte-for-byte identical. The value assigned to `*ap.SubParsers.Value` is now the normalised (lowercase) form in the case-insensitive path, which matches the key stored by `AddSubParser`; no caller can rely on the previous raw form since the raw form never reached the map in the first place.