### PR TITLE
Fix ArgumentGroup.Register unconditional write to LongNameToArgument (#22)

### DIFF
--- a/argumentgroup/argument_group.go
+++ b/argumentgroup/argument_group.go
@@ -83,8 +83,6 @@ func (ag *ArgumentGroup) Register(arg arguments.Argument) error {
 		ag.LongNameToArgument[arg.GetLongName()] = arg
 	}
 
-	ag.LongNameToArgument[arg.GetLongName()] = arg
-
 	ag.Arguments = append(ag.Arguments, arg)
 	return nil
 }

--- a/argumentgroup/argument_group_test.go
+++ b/argumentgroup/argument_group_test.go
@@ -21,6 +21,40 @@ func TestArgumentGroup_Register_ExistingArgument(t *testing.T) {
 	}
 }
 
+func TestArgumentGroup_Register_ShortNameOnlyDoesNotPolluteLongNameMap(t *testing.T) {
+	var v1, v2 bool
+	ag := ArgumentGroup{Name: "G"}
+
+	if err := ag.NewBoolArgument(&v1, "x", "", false, "help"); err != nil {
+		t.Fatalf("unexpected error registering first arg: %v", err)
+	}
+	if _, ok := ag.LongNameToArgument[""]; ok {
+		t.Fatalf("LongNameToArgument should not contain an empty-string key, got %v", ag.LongNameToArgument)
+	}
+
+	if err := ag.NewBoolArgument(&v2, "x", "", false, "help"); err == nil {
+		t.Fatalf("duplicate short name should be rejected, got nil error")
+	}
+}
+
+func TestArgumentGroup_Register_TwoShortNameOnlyArgsCoexist(t *testing.T) {
+	var v1, v2 bool
+	ag := ArgumentGroup{Name: "G"}
+
+	if err := ag.NewBoolArgument(&v1, "x", "", false, "help"); err != nil {
+		t.Fatalf("unexpected error registering first arg: %v", err)
+	}
+	if err := ag.NewBoolArgument(&v2, "y", "", false, "help"); err != nil {
+		t.Fatalf("second short-only arg must register without error, got %v", err)
+	}
+	if len(ag.Arguments) != 2 {
+		t.Fatalf("expected 2 registered arguments, got %d", len(ag.Arguments))
+	}
+	if len(ag.LongNameToArgument) != 0 {
+		t.Fatalf("LongNameToArgument should be empty, got %v", ag.LongNameToArgument)
+	}
+}
+
 func TestArgumentGroup_PrintArgumentTree(t *testing.T) {
 	var stringValue string
 	argGroup := ArgumentGroup{Name: "Test Group"}


### PR DESCRIPTION
### Linked Issue
Closes #22

### Root Cause
`ArgumentGroup.Register` guarded the first write to `LongNameToArgument` behind `len(arg.GetLongName()) != 0`, but then repeated the assignment immediately after the guard:

```go
if len(arg.GetLongName()) != 0 {
    if _, exists := ag.LongNameToArgument[arg.GetLongName()]; exists {
        return fmt.Errorf("argument with long name %s already exists", arg.GetLongName())
    }
    ag.LongNameToArgument[arg.GetLongName()] = arg
}

ag.LongNameToArgument[arg.GetLongName()] = arg   // runs unconditionally
```

For arguments that only carry a short name, the unconditional write inserted an entry keyed by the empty string. A second short-name-only argument then "duplicated" an empty key (the guard does not check for it), silently overwriting the first and leaving a single stale entry in the map.

### Fix Description
Remove the unconditional second assignment. The guarded block already does the right thing: it writes the map entry only when a long name is actually present and returns an error on duplicates. No other call site depended on the empty-key entry — it was a pure regression introduced when the long-name guard was added.

### How Verified
- **Tests:** added two cases:
  - `TestArgumentGroup_Register_ShortNameOnlyDoesNotPolluteLongNameMap` — asserts that registering a short-name-only argument does not create an empty-string entry, and that a duplicate short name is still detected. Fails on `main`.
  - `TestArgumentGroup_Register_TwoShortNameOnlyArgsCoexist` — asserts that two short-name-only arguments with distinct short names both register without error and that `LongNameToArgument` stays empty. Fails on `main` (the first gets silently overwritten by the second in the empty-key slot).
- Ran `go test ./...` — all existing tests still pass.

### Test Coverage
- **Added:** `argumentgroup/argument_group_test.go::TestArgumentGroup_Register_ShortNameOnlyDoesNotPolluteLongNameMap`, `TestArgumentGroup_Register_TwoShortNameOnlyArgsCoexist`.

### Scope of Change
- **Files changed:** `argumentgroup/argument_group.go`, `argumentgroup/argument_group_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very low. The removed statement was either a duplicate of the guarded write (long-name case) or a bug (short-name-only case). Callers that read `LongNameToArgument` with a long-name key are unaffected; callers that read it with the empty string now correctly get `ok = false`.