### PR TITLE
Fix positional argument parse errors being silently ignored (Fixes #29)

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -167,8 +167,12 @@ func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 		missingPositionalArguments := []string{}
 		for k, posarg := range ap.PositionalArguments {
 			if k < len(potentialPositionalArguments) {
-				posarg.Consume([]string{potentialPositionalArguments[k]})
-				parsingState.ParsedArguments.AddPositionalArgument(&posarg)
+				_, err := posarg.Consume([]string{potentialPositionalArguments[k]})
+				if err != nil {
+					parsingState.AddErrorMessage(fmt.Sprintf("Error parsing positional argument <%s>: %s", posarg.GetName(), err))
+				} else {
+					parsingState.ParsedArguments.AddPositionalArgument(&posarg)
+				}
 			} else {
 				missingPositionalArguments = append(missingPositionalArguments, posarg.GetName())
 			}

--- a/parser/positional_error_test.go
+++ b/parser/positional_error_test.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestPositionalIntInvalidValueReportsError verifies that an invalid value for an
+// integer positional argument is surfaced as a parse error and causes ParseFrom to
+// exit with a non-zero status, instead of being silently ignored.
+//
+// ParseFrom calls os.Exit(1) when it records error messages, so the error path is
+// exercised in a subprocess and the exit code is inspected from the parent.
+func TestPositionalIntInvalidValueReportsError(t *testing.T) {
+	if os.Getenv("GOOPTS_POSITIONAL_ERROR_SUBPROCESS") == "1" {
+		var count int
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+		if err := ap.NewIntPositionalArgument(&count, "count", "the count"); err != nil {
+			// Registration failure is a different problem; exit 2 to distinguish.
+			os.Exit(2)
+		}
+		ps := &ParsingState{}
+		ps.SetRawArguments([]string{"abc"})
+		// "abc" cannot be parsed as an integer: ParseFrom must record an error and os.Exit(1).
+		ap.ParseFrom(0, ps)
+		// Reaching here means the error was swallowed (the bug): signal failure.
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestPositionalIntInvalidValueReportsError")
+	cmd.Env = append(os.Environ(), "GOOPTS_POSITIONAL_ERROR_SUBPROCESS=1")
+	err := cmd.Run()
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected the parser to exit non-zero on an invalid integer positional, but it exited 0 (error was silently ignored)")
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 from a positional parse error, got %d", exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #29`

### Root Cause
The positional-argument loop in `ArgumentsParser.ParseFrom()` called `posarg.Consume(...)` and discarded its return values. `IntPositionalArgument.Consume` returns a non-nil error when the supplied token cannot be parsed as an integer, but the caller never inspected it, so a malformed positional value left the target variable at its zero value and parsing continued as if the input were valid. The named-argument loop in the same function already propagates `Consume` errors into `parsingState.ErrorMessages`; the positional loop was simply missing the equivalent handling.

### Fix Description
Capture the error returned by `posarg.Consume(...)` and, when non-nil, append a descriptive message to `parsingState.ErrorMessages` (mirroring the named-argument path). Only register the argument as successfully parsed when `Consume` succeeds. When an error is recorded, the existing end-of-`ParseFrom` logic prints usage and exits with a non-zero status.

### How Verified
- **Runtime:** A minimal program with one integer positional argument.
  - Before: `./prog abc` printed `count=0` and exited `0`.
  - After: `./prog abc` prints `[!] Error parsing positional argument <count>: strconv.Atoi: parsing "abc": invalid syntax` and exits `1`. `./prog 42` still sets `count=42` and exits `0`.
- **Tests:** Added `TestPositionalIntInvalidValueReportsError` (parser package). It runs the parser in a subprocess with an invalid integer positional and asserts a non-zero (exit code 1) result. The test fails against the unfixed code and passes with the fix. Full suite (`go test ./...`) passes.

### Test Coverage
- **Added:** `parser/positional_error_test.go` — `TestPositionalIntInvalidValueReportsError`.

### Scope of Change
- **Files changed:** `parser/parse.go`, `parser/positional_error_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the change only affects the previously-silent error path for positional arguments. Valid inputs are unaffected; malformed positional values now fail loudly (a strict improvement), consistent with named-argument handling. Safe to merge without staged rollout.