### PR TITLE
Fix unknown flags being silently ignored (Fixes #31)

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -81,7 +81,8 @@ func (ap *ArgumentsParser) populateMaps() {
 //   - Detects the presence of help flags ("-h" or "--help") and displays usage information.
 //   - Separates positional arguments from named arguments based on the order of inputs.
 //   - Validates that all required positional and named arguments are provided and parses them.
-//   - Displays error messages for missing or extra arguments and exits if any errors are detected.
+//   - Reports an error for any argument starting with "-" that matches no registered short or long name.
+//   - Displays error messages for missing, unknown or extra arguments and exits if any errors are detected.
 //
 // Note:
 //
@@ -92,8 +93,8 @@ func (ap *ArgumentsParser) populateMaps() {
 //
 // Errors:
 //
-//	If required arguments are missing or extra positional arguments are found, error messages
-//	will be displayed, and the program will exit with a non-zero status.
+//	If required arguments are missing, unknown flags are supplied, or extra positional arguments
+//	are found, error messages will be displayed, and the program will exit with a non-zero status.
 func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 	ap.populateMaps()
 
@@ -204,28 +205,41 @@ func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 		}
 
 		// Parse all other arguments
+		// Positions consumed as the value of a recognized flag are tracked so that
+		// values which look like flags (e.g. "--port -1") are not reported as unknown.
+		consumedAsValue := make(map[int]bool)
 		for k, otherarg := range otherArguments {
 			if strings.HasPrefix(otherarg, "--") {
 				// Long flag name
 				if _, exists := ap.longNameToArgument[otherarg]; exists {
 					arg := ap.longNameToArgument[otherarg]
-					_, err := arg.Consume(otherArguments[k:])
+					remaining, err := arg.Consume(otherArguments[k:])
 					if err != nil {
 						parsingState.AddErrorMessage(fmt.Sprintf("Error parsing argument: %s", err))
 					} else {
 						parsingState.ParsedArguments.AddArgument(&arg)
 					}
+					for i := k + 1; i < len(otherArguments)-len(remaining); i++ {
+						consumedAsValue[i] = true
+					}
+				} else if !consumedAsValue[k] {
+					parsingState.AddErrorMessage(fmt.Sprintf("Unknown argument \"%s\".", otherarg))
 				}
 			} else if strings.HasPrefix(otherarg, "-") {
 				// Short flag name
 				if _, exists := ap.shortNameToArgument[otherarg]; exists {
 					arg := ap.shortNameToArgument[otherarg]
-					_, err := arg.Consume(otherArguments[k:])
+					remaining, err := arg.Consume(otherArguments[k:])
 					if err != nil {
 						parsingState.AddErrorMessage(fmt.Sprintf("Error parsing argument: %s", err))
 					} else {
 						parsingState.ParsedArguments.AddArgument(&arg)
 					}
+					for i := k + 1; i < len(otherArguments)-len(remaining); i++ {
+						consumedAsValue[i] = true
+					}
+				} else if !consumedAsValue[k] {
+					parsingState.AddErrorMessage(fmt.Sprintf("Unknown argument \"%s\".", otherarg))
 				}
 			}
 		}

--- a/parser/unknown_argument_test.go
+++ b/parser/unknown_argument_test.go
@@ -1,0 +1,95 @@
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// runParserSubprocess re-executes the given test in a subprocess with the
+// GOOPTS_UNKNOWN_ARGUMENT_SUBPROCESS environment marker set, and returns the exit
+// code of that subprocess. ParseFrom calls os.Exit when it records error messages,
+// so the error paths have to be exercised out of process.
+func runParserSubprocess(t *testing.T, testName string) int {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run="+testName)
+	cmd.Env = append(os.Environ(), "GOOPTS_UNKNOWN_ARGUMENT_SUBPROCESS=1")
+	err := cmd.Run()
+
+	if err == nil {
+		return 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("running %s in a subprocess failed: %s", testName, err)
+	}
+	return exitErr.ExitCode()
+}
+
+// TestUnknownArgumentReportsError verifies that flags matching no registered short or
+// long name are surfaced as parse errors and cause ParseFrom to exit with a non-zero
+// status, instead of being silently ignored.
+func TestUnknownArgumentReportsError(t *testing.T) {
+	if os.Getenv("GOOPTS_UNKNOWN_ARGUMENT_SUBPROCESS") == "1" {
+		var verbose bool
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+		if err := ap.NewBoolArgument(&verbose, "-v", "--verbose", false, "verbose"); err != nil {
+			// Registration failure is a different problem; exit 2 to distinguish.
+			os.Exit(2)
+		}
+		ap.ParsingState.SetRawArguments([]string{"--typo-flag", "-x"})
+		// Neither "--typo-flag" nor "-x" is registered: ParseFrom must record errors and os.Exit(1).
+		ap.ParseFrom(0, &ap.ParsingState)
+		// Reaching here means the unknown flags were swallowed (the bug): signal failure.
+		os.Exit(0)
+	}
+
+	if code := runParserSubprocess(t, "TestUnknownArgumentReportsError"); code != 1 {
+		if code == 0 {
+			t.Fatalf("expected the parser to exit non-zero on unknown flags, but it exited 0 (unknown flags were silently ignored)")
+		}
+		t.Fatalf("expected exit code 1 from unknown flags, got %d", code)
+	}
+}
+
+// TestKnownArgumentsWithFlagLikeValuesAreAccepted verifies that a value which looks like
+// a flag, such as the negative integer in "--port -1", is recognized as the value of the
+// preceding argument and not reported as an unknown flag.
+func TestKnownArgumentsWithFlagLikeValuesAreAccepted(t *testing.T) {
+	if os.Getenv("GOOPTS_UNKNOWN_ARGUMENT_SUBPROCESS") == "1" {
+		var port int
+		var name string
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+		if err := ap.NewIntArgument(&port, "-p", "--port", 0, false, "port"); err != nil {
+			os.Exit(2)
+		}
+		if err := ap.NewStringArgument(&name, "-n", "--name", "", false, "name"); err != nil {
+			os.Exit(2)
+		}
+		ap.ParsingState.SetRawArguments([]string{"--port", "-1", "-n", "-dash-value"})
+		// Both values start with "-" but are operands of registered flags: no error expected.
+		ap.ParseFrom(0, &ap.ParsingState)
+		if port != -1 {
+			os.Exit(3)
+		}
+		if name != "-dash-value" {
+			os.Exit(4)
+		}
+		os.Exit(0)
+	}
+
+	switch code := runParserSubprocess(t, "TestKnownArgumentsWithFlagLikeValuesAreAccepted"); code {
+	case 0:
+	case 1:
+		t.Fatalf("expected flag-like values of registered arguments to parse cleanly, but the parser exited 1 (they were reported as unknown arguments)")
+	case 3:
+		t.Fatalf("expected --port to be set to -1")
+	case 4:
+		t.Fatalf("expected -n to be set to \"-dash-value\"")
+	default:
+		t.Fatalf("unexpected exit code %d", code)
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #31`

### Root Cause

In `ParseFrom`, the loop over non-positional tokens looked each `--long` token up in `ap.longNameToArgument` and each `-short` token up in `ap.shortNameToArgument` inside an `if _, exists := ...; exists` block with no `else` branch. A token that matched neither map simply fell through the loop body, so no error message was ever appended to `parsingState.ErrorMessages` and the exit check at the end of `ParseFrom` was never triggered.

The loop also discarded the remaining-arguments slice returned by `Argument.Consume`, so it kept no record of which tokens had already been eaten as the value of a preceding flag. Without that information there was no way to distinguish an unknown flag from a flag-shaped operand such as the `-1` in `--port -1`, which is why simply rejecting every unmatched `-`-prefixed token was not sufficient.

### Fix Description

Both lookups now have an `else` branch that records `Unknown argument "<token>".` via `parsingState.AddErrorMessage`, which routes into the existing usage-and-exit path at the end of `ParseFrom`.

To keep flag-shaped values working, the return value of `Consume` — previously discarded — is used to compute how many tokens each recognized flag consumed, and those positions are marked in a `consumedAsValue` set. The unknown-argument branch skips positions in that set, so `--port -1` and `--name=-weird` still parse as values while `--typo-flag` is rejected.

Recognized-flag handling is otherwise untouched: each token is still visited once in the same order, and `Consume` is still called with `otherArguments[k:]`, so no existing parsing behavior changes.

### How Verified

**Runtime**, with a program registering `-v/--verbose` and `-n/--name`:

Before:

```
$ ./repro --typo-flag --unknown 42 -n bob
parsed ok: verbose=false name="bob" errors=[]
exit=0
```

After:

```
$ ./repro --typo-flag --unknown 42 -n bob
[!] Unknown argument "--typo-flag".
[!] Unknown argument "--unknown".
exit=1

$ ./repro -v -n bob
parsed ok: verbose=true name="bob" errors=[]
exit=0

$ ./repro --name=-weird
parsed ok: verbose=false name="-weird" errors=[]
exit=0
```

**Tests:** `go test ./...` passes on the whole module. With `parser/parse.go` reverted to its pre-fix state, `TestUnknownArgumentReportsError` fails with "expected the parser to exit non-zero on unknown flags, but it exited 0", confirming the test covers the defect rather than passing incidentally.

### Test Coverage

**Added:** `parser/unknown_argument_test.go`

- `TestUnknownArgumentReportsError` — asserts `ParseFrom` exits 1 when given `--typo-flag -x` against a parser that registers neither.
- `TestKnownArgumentsWithFlagLikeValuesAreAccepted` — asserts `--port -1 -n -dash-value` parses cleanly and that `port == -1` and `name == "-dash-value"`, guarding against false positives on flag-shaped values.

Both exercise `ParseFrom` in a subprocess, following the existing pattern in `parser/positional_error_test.go`, because `ParseFrom` calls `os.Exit` on error.

### Scope of Change

- **Files changed:** `parser/parse.go`, `parser/unknown_argument_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The doc comment on `ParseFrom` was updated to describe the newly reported error condition.

### Risk and Rollout

Input that was previously accepted by mistake is now rejected, so any downstream tool invoked with an unsupported flag will start failing with exit code 1 instead of silently ignoring it — that is the intended correction, but it is a user-visible behavior change for callers relying on the old leniency. Parsing of valid input is unchanged.

### Notes

A non-flag token that follows an unknown flag — the `42` in `--unknown 42` — is still dropped without an error, because an unknown flag's arity cannot be known. Reporting stray non-flag tokens that appear after flags is a distinct gap and is not addressed here.
