### PR TITLE
Fix nil map panic when ParseFrom is given an external ParsingState (Fixes #33)

### DIFF
--- a/parser/external_parsing_state_test.go
+++ b/parser/external_parsing_state_test.go
@@ -1,0 +1,60 @@
+package parser
+
+import (
+	"testing"
+)
+
+// TestParseFromExternalParsingStateNamedArgument verifies that ParseFrom initializes the
+// ParsedArguments maps of the ParsingState it was given, instead of the parser's own
+// ap.ParsingState. Before the fix, recording the successfully parsed "-n bob" panicked
+// with "assignment to entry in nil map" because the written-to maps were never allocated.
+func TestParseFromExternalParsingStateNamedArgument(t *testing.T) {
+	var name string
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+	if err := ap.NewStringArgument(&name, "-n", "--name", "default", false, "name"); err != nil {
+		t.Fatalf("NewStringArgument failed: %v", err)
+	}
+
+	ps := &ParsingState{}
+	ps.SetRawArguments([]string{"-n", "bob"})
+	ap.ParseFrom(0, ps)
+
+	if name != "bob" {
+		t.Fatalf("expected --name to be %q, got %q", "bob", name)
+	}
+	if got := len(ps.GetErrorMessages()); got != 0 {
+		t.Fatalf("expected no error messages, got %d: %v", got, ps.GetErrorMessages())
+	}
+	if _, exists := ps.ParsedArguments.ShortNameToArgument["-n"]; !exists {
+		t.Fatalf("expected \"-n\" to be recorded in the parsing state that was passed to ParseFrom")
+	}
+	if _, exists := ps.ParsedArguments.LongNameToArgument["--name"]; !exists {
+		t.Fatalf("expected \"--name\" to be recorded in the parsing state that was passed to ParseFrom")
+	}
+}
+
+// TestParseFromExternalParsingStatePositionalArgument verifies the same invariant for
+// positional arguments, which are recorded through AddPositionalArgument.
+func TestParseFromExternalParsingStatePositionalArgument(t *testing.T) {
+	var count int
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+	if err := ap.NewIntPositionalArgument(&count, "count", "the count"); err != nil {
+		t.Fatalf("NewIntPositionalArgument failed: %v", err)
+	}
+
+	ps := &ParsingState{}
+	ps.SetRawArguments([]string{"7"})
+	ap.ParseFrom(0, ps)
+
+	if count != 7 {
+		t.Fatalf("expected count to be 7, got %d", count)
+	}
+	if got := len(ps.GetErrorMessages()); got != 0 {
+		t.Fatalf("expected no error messages, got %d: %v", got, ps.GetErrorMessages())
+	}
+	if _, exists := ps.ParsedArguments.PositionalArguments["count"]; !exists {
+		t.Fatalf("expected \"count\" to be recorded in the parsing state that was passed to ParseFrom")
+	}
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -22,12 +22,17 @@ import (
 //     respective maps. If an argument is required, it adds it to the `requiredArguments` slice.
 //   - Registers arguments from all named subgroups in the `Groups` map, similarly storing their names
 //     and tracking required arguments.
+//   - Initializes the `ParsedArguments` maps of `parsingState`, which is the state parsing results are
+//     recorded into and is not necessarily the parser's own `ParsingState`.
+//
+// Parameters:
+//   - parsingState: The parsing state that will be populated during the parse.
 //
 // Note:
 //
 //	This method should be called before parsing command-line arguments to ensure that all arguments
 //	are correctly registered and accessible for lookup during the parsing process.
-func (ap *ArgumentsParser) populateMaps() {
+func (ap *ArgumentsParser) populateMaps(parsingState *ParsingState) {
 	// Reset lookup maps and per-parse slices so repeated calls stay consistent
 	ap.shortNameToArgument = make(map[string]arguments.Argument)
 	ap.longNameToArgument = make(map[string]arguments.Argument)
@@ -59,14 +64,16 @@ func (ap *ArgumentsParser) populateMaps() {
 		}
 	}
 
-	if ap.ParsingState.ParsedArguments.PositionalArguments == nil {
-		ap.ParsingState.ParsedArguments.PositionalArguments = make(map[string]*positionals.PositionalArgument)
+	// Initialize the maps of the parsing state that will be written to during this parse,
+	// which is not necessarily the parser's own ap.ParsingState
+	if parsingState.ParsedArguments.PositionalArguments == nil {
+		parsingState.ParsedArguments.PositionalArguments = make(map[string]*positionals.PositionalArgument)
 	}
-	if ap.ParsingState.ParsedArguments.LongNameToArgument == nil {
-		ap.ParsingState.ParsedArguments.LongNameToArgument = make(map[string]*arguments.Argument)
+	if parsingState.ParsedArguments.LongNameToArgument == nil {
+		parsingState.ParsedArguments.LongNameToArgument = make(map[string]*arguments.Argument)
 	}
-	if ap.ParsingState.ParsedArguments.ShortNameToArgument == nil {
-		ap.ParsingState.ParsedArguments.ShortNameToArgument = make(map[string]*arguments.Argument)
+	if parsingState.ParsedArguments.ShortNameToArgument == nil {
+		parsingState.ParsedArguments.ShortNameToArgument = make(map[string]*arguments.Argument)
 	}
 }
 
@@ -95,7 +102,7 @@ func (ap *ArgumentsParser) populateMaps() {
 //	If required arguments are missing or extra positional arguments are found, error messages
 //	will be displayed, and the program will exit with a non-zero status.
 func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
-	ap.populateMaps()
+	ap.populateMaps(parsingState)
 
 	// Print the banner if it is set and the option is enabled
 	if len(ap.Banner) != 0 && ap.Options.ShowBannerOnRun {

--- a/parser/populate_maps_test.go
+++ b/parser/populate_maps_test.go
@@ -15,7 +15,7 @@ func TestPopulateMaps_DefaultGroupRegisteredOnce(t *testing.T) {
 		t.Fatalf("NewIntArgument(b) failed: %v", err)
 	}
 
-	ap.populateMaps()
+	ap.populateMaps(&ap.ParsingState)
 
 	if got := len(ap.allArguments); got != 2 {
 		t.Fatalf("expected 2 arguments in allArguments, got %d", got)
@@ -25,8 +25,8 @@ func TestPopulateMaps_DefaultGroupRegisteredOnce(t *testing.T) {
 	}
 
 	// Calling populateMaps again must not grow the slices.
-	ap.populateMaps()
-	ap.populateMaps()
+	ap.populateMaps(&ap.ParsingState)
+	ap.populateMaps(&ap.ParsingState)
 
 	if got := len(ap.allArguments); got != 2 {
 		t.Fatalf("expected 2 arguments in allArguments after repeated calls, got %d", got)
@@ -53,7 +53,7 @@ func TestPopulateMaps_MixedGroupsCountedOnce(t *testing.T) {
 		t.Fatalf("group.NewIntArgument failed: %v", err)
 	}
 
-	ap.populateMaps()
+	ap.populateMaps(&ap.ParsingState)
 
 	if got := len(ap.allArguments); got != 2 {
 		t.Fatalf("expected 2 arguments in allArguments, got %d", got)


### PR DESCRIPTION
### Linked Issue

`Closes #33`

### Root Cause

`ParseFrom` takes the `ParsingState` to populate as a parameter and records every result through it — `parsingState.ParsedArguments.AddPositionalArgument(...)` and `parsingState.ParsedArguments.AddArgument(...)`. `populateMaps`, however, allocated the three `ParsedArguments` maps on the parser's own `ap.ParsingState` field, which it referenced directly rather than receiving the state as an argument.

The two coincide only because `Parse()` calls `ap.ParseFrom(1, &ap.ParsingState)`. For any other use of the exported `ParseFrom`, the allocation target and the write target were different `ParsedArguments` values, so the maps being written to were still nil and the assignments in `ParsedArguments.AddArgument` / `AddPositionalArgument` panicked with `assignment to entry in nil map` on the first argument that parsed successfully. The panic sat on the success path, which is why the existing tests never reached it: they either go through `Parse()`, or pass an external state together with input that fails before any result is recorded.

### Fix Description

`populateMaps` now takes the `*ParsingState` that is about to be populated and initializes that state's maps, so allocation and writes always address the same value. The call site in `ParseFrom` passes its own `parsingState` parameter.

The nil-checks are preserved, so the method stays idempotent across repeated parses and remains safe for the subparser path, where a child parser is handed the parent's already-initialized state.

Making `AddArgument` and `AddPositionalArgument` lazily allocate their own maps was considered and rejected: it would spread the initialization invariant across two files and leave `populateMaps` allocating maps on a state that is never written to.

### How Verified

**Runtime**, calling `ParseFrom` with an externally created `ParsingState`:

Before, named argument (`-n bob` against a registered `-n/--name`):

```
panic: assignment to entry in nil map
	parser/parsing_state.go:60
	parser/parse.go:227
exit status 2
```

Before, positional argument (`7` against a registered int positional `count`):

```
panic: assignment to entry in nil map
	parser/parsing_state.go:73
	parser/parse.go:174
```

After, both cases:

```
name = "bob", recorded = true
count = 7
```

The `Parse()` path was re-checked after the change and is unchanged: `./repro -v -n bob` still yields `verbose=true name="bob" errors=[]`.

**Tests:** `go test ./...` passes across the module. Re-pointing only the three initialization blocks back at `ap.ParsingState` (leaving the new signature in place) makes `TestParseFromExternalParsingStateNamedArgument` panic with `assignment to entry in nil map`, confirming the new tests fail without the fix.

### Test Coverage

**Added:** `parser/external_parsing_state_test.go`

- `TestParseFromExternalParsingStateNamedArgument` — parses `-n bob` through an external `&ParsingState{}`, asserting no panic, no error messages, the value applied, and the argument recorded under both `-n` and `--name` in the state that was passed in.
- `TestParseFromExternalParsingStatePositionalArgument` — same for a positional argument, asserting `count == 7` and that `count` is recorded in `ps.ParsedArguments.PositionalArguments`.

### Scope of Change

- **Files changed:** `parser/parse.go`, `parser/populate_maps_test.go`, `parser/external_parsing_state_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `populateMaps` is unexported, so the signature change is internal; the four call sites in `parser/populate_maps_test.go` were updated to pass `&ap.ParsingState`, which is the state those tests already asserted against, and the doc comment now documents the parameter.

### Risk and Rollout

Local and contained: the only behavioral difference is which `ParsedArguments` value gets its maps allocated, and the previous behavior on that path was a panic. Callers that go through `Parse()` see no change at all.

### Notes

With an external `ParsingState`, the `ap.ParsingState`-based accessors such as `ArgumentIsPresent` still read the parser's own state and therefore report nothing for arguments recorded into the caller's state. That is a pre-existing API asymmetry, not a regression from this change — reading a nil map never panicked — and it is left as is here.
