### PR TITLE
Fix required argument in a mutually exclusive group breaking its group (Fixes #35)

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -11,6 +11,19 @@ import (
 	"github.com/TheManticoreProject/goopts/positionals"
 )
 
+// isMutuallyExclusiveGroup reports whether a group type enforces mutual exclusivity between its
+// members, in which case the group rule alone decides whether a member has to be set.
+//
+// Parameters:
+//   - groupType: The type of the argument group.
+//
+// Returns:
+// - true for the required and not required mutually exclusive group types, false otherwise.
+func isMutuallyExclusiveGroup(groupType int) bool {
+	return groupType == argumentgroup.ARGUMENT_GROUP_TYPE_REQUIRED_MUTUALLY_EXCLUSIVE ||
+		groupType == argumentgroup.ARGUMENT_GROUP_TYPE_NOT_REQUIRED_MUTUALLY_EXCLUSIVE
+}
+
 // populateMaps initializes the maps that store the associations between short and long argument names
 // and their corresponding argument structures. This method is called to prepare the parser for argument
 // handling and validation.
@@ -19,7 +32,8 @@ import (
 //   - It creates or resets the `shortNameToArgument` and `longNameToArgument` maps to ensure they
 //     are up-to-date.
 //   - Registers arguments from the default argument group, storing their short and long names in the
-//     respective maps. If an argument is required, it adds it to the `requiredArguments` slice.
+//     respective maps. If an argument is required, it adds it to the `requiredArguments` slice, unless
+//     it belongs to a mutually exclusive group, where the group rule decides whether it has to be set.
 //   - Registers arguments from all named subgroups in the `Groups` map, similarly storing their names
 //     and tracking required arguments.
 //   - Initializes the `ParsedArguments` maps of `parsingState`, which is the state parsing results are
@@ -57,7 +71,10 @@ func (ap *ArgumentsParser) populateMaps(parsingState *ParsingState) {
 			if longName := arg.GetLongName(); longName != "" {
 				ap.longNameToArgument[longName] = arg
 			}
-			if arg.IsRequired() {
+			// In a mutually exclusive group, whether a member has to be set is decided by the
+			// group rule, so its individual required flag is not enforced on its own: doing so
+			// would contradict the group and make every other member unusable
+			if arg.IsRequired() && !isMutuallyExclusiveGroup(group.Type) {
 				ap.requiredArguments = append(ap.requiredArguments, arg)
 			}
 			ap.allArguments = append(ap.allArguments, arg)

--- a/parser/required_in_exclusive_group_test.go
+++ b/parser/required_in_exclusive_group_test.go
@@ -1,0 +1,142 @@
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestRequiredInRequiredMutuallyExclusiveGroupNotUnconditionallyRequired verifies that a
+// member of a required mutually exclusive group that was registered with required: true is
+// not additionally enforced as unconditionally required. Before the fix, populateMaps put it
+// in ap.requiredArguments, which reported it as missing even when the group was satisfied by
+// another member, and produced a second error line naming the same argument.
+func TestRequiredInRequiredMutuallyExclusiveGroupNotUnconditionallyRequired(t *testing.T) {
+	var mode, modeAlt string
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+
+	grp, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Mode")
+	if err != nil {
+		t.Fatalf("NewRequiredMutuallyExclusiveArgumentGroup failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&mode, "-m", "--mode", "", true, "mode"); err != nil {
+		t.Fatalf("group.NewStringArgument(--mode) failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&modeAlt, "-M", "--mode-alt", "", false, "mode alt"); err != nil {
+		t.Fatalf("group.NewStringArgument(--mode-alt) failed: %v", err)
+	}
+
+	ap.populateMaps(&ap.ParsingState)
+
+	if got := len(ap.requiredArguments); got != 0 {
+		t.Fatalf("expected no unconditionally required arguments for a mutually exclusive group, got %d", got)
+	}
+}
+
+// TestRequiredInNotRequiredMutuallyExclusiveGroupNotUnconditionallyRequired verifies the same
+// for the not required mutually exclusive group type, where enforcing a member's required flag
+// would force that member and make every other member of the group unusable.
+func TestRequiredInNotRequiredMutuallyExclusiveGroupNotUnconditionallyRequired(t *testing.T) {
+	var a, b string
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+
+	grp, err := ap.NewNotRequiredMutuallyExclusiveArgumentGroup("Output")
+	if err != nil {
+		t.Fatalf("NewNotRequiredMutuallyExclusiveArgumentGroup failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&a, "-o", "--out-file", "", true, "out file"); err != nil {
+		t.Fatalf("group.NewStringArgument(--out-file) failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&b, "-j", "--out-json", "", false, "out json"); err != nil {
+		t.Fatalf("group.NewStringArgument(--out-json) failed: %v", err)
+	}
+
+	ap.populateMaps(&ap.ParsingState)
+
+	if got := len(ap.requiredArguments); got != 0 {
+		t.Fatalf("expected no unconditionally required arguments for a mutually exclusive group, got %d", got)
+	}
+}
+
+// TestRequiredInDependentGroupStaysRequired verifies that the fix is limited to mutually
+// exclusive groups: a required argument in a dependent group is coherent with the group rule,
+// which forces every member once one is set, so it stays unconditionally required.
+func TestRequiredInDependentGroupStaysRequired(t *testing.T) {
+	var host, port string
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+
+	grp, err := ap.NewDependentArgumentGroup("Proxy")
+	if err != nil {
+		t.Fatalf("NewDependentArgumentGroup failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&host, "-x", "--proxy-host", "", true, "proxy host"); err != nil {
+		t.Fatalf("group.NewStringArgument(--proxy-host) failed: %v", err)
+	}
+	if err := grp.NewStringArgument(&port, "-X", "--proxy-port", "", false, "proxy port"); err != nil {
+		t.Fatalf("group.NewStringArgument(--proxy-port) failed: %v", err)
+	}
+
+	ap.populateMaps(&ap.ParsingState)
+
+	if got := len(ap.requiredArguments); got != 1 {
+		t.Fatalf("expected 1 unconditionally required argument in a dependent group, got %d", got)
+	}
+}
+
+// TestExclusiveGroupSatisfiedByOtherMemberParses verifies the user visible consequence of the
+// fix: supplying the other member of the group is enough for the parse to succeed. Before the
+// fix, ParseFrom recorded "Missing required argument \"--mode\"" and exited 1, so --mode-alt
+// could never be used.
+//
+// ParseFrom calls os.Exit(1) when it records error messages, so the parse runs in a subprocess
+// and the exit code is inspected from the parent.
+func TestExclusiveGroupSatisfiedByOtherMemberParses(t *testing.T) {
+	if os.Getenv("GOOPTS_EXCLUSIVE_GROUP_SUBPROCESS") == "1" {
+		var mode, modeAlt string
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+
+		grp, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Mode")
+		if err != nil {
+			// Registration failure is a different problem; exit 2 to distinguish.
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&mode, "-m", "--mode", "", true, "mode"); err != nil {
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&modeAlt, "-M", "--mode-alt", "", false, "mode alt"); err != nil {
+			os.Exit(2)
+		}
+
+		ap.ParsingState.SetRawArguments([]string{"--mode-alt", "X"})
+		ap.ParseFrom(0, &ap.ParsingState)
+
+		if modeAlt != "X" {
+			os.Exit(3)
+		}
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestExclusiveGroupSatisfiedByOtherMemberParses")
+	cmd.Env = append(os.Environ(), "GOOPTS_EXCLUSIVE_GROUP_SUBPROCESS=1")
+	err := cmd.Run()
+
+	if err == nil {
+		return
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("running the parse in a subprocess failed: %s", err)
+	}
+	switch exitErr.ExitCode() {
+	case 1:
+		t.Fatalf("expected the parse to succeed when the group is satisfied by --mode-alt, but the parser reported errors and exited 1")
+	case 3:
+		t.Fatalf("expected --mode-alt to be set to \"X\"")
+	default:
+		t.Fatalf("unexpected exit code %d", exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #35`

### Root Cause

`populateMaps` builds `ap.requiredArguments` by walking every group and appending each argument whose `IsRequired()` is true, without looking at `group.Type`. `ParseFrom` then applies two independent checks to such an argument: the unconditional "Missing required argument" check, and the group rule for its group.

For a mutually exclusive group those checks contradict each other. The group rule is satisfied by exactly one member being present, while the required check demands that one specific member be present. Both fired, so the argument appeared on two error lines, and no invocation could satisfy both checks unless that specific member was supplied — which is precisely what an exclusive group exists to avoid. The other members of the group became unreachable.

### Fix Description

`populateMaps` now skips the `requiredArguments` registration for arguments that belong to a mutually exclusive group, so membership of the group is what decides whether a member has to be set. A small predicate, `isMutuallyExclusiveGroup`, keeps the condition readable and covers both exclusive group types:

- `ARGUMENT_GROUP_TYPE_REQUIRED_MUTUALLY_EXCLUSIVE` — the group already requires exactly one member; enforcing one member individually contradicts it.
- `ARGUMENT_GROUP_TYPE_NOT_REQUIRED_MUTUALLY_EXCLUSIVE` — enforcing a member individually forces that member, so every other member then trips "cannot be set together". Same defect, so it is covered here too.

`ARGUMENT_GROUP_TYPE_DEPENDENT` and `ARGUMENT_GROUP_TYPE_NORMAL` are deliberately left alone: requiring a member of a dependent group is coherent with the group rule, which forces all members once one is set.

Rejecting `required: true` at registration time with an error was considered and rejected: it would break existing callers that pass `true` today, and the forgiving behavior — let the group rule govern — produces the correct parse for those callers instead of a hard failure.

### How Verified

**Runtime**, with three required mutually exclusive groups where `--mode` is registered `required: true`:

Before, no arguments supplied — `--mode` reported twice:

```
[!] Missing required argument "--mode"
[!] At least one of the arguments "--from-file", "--from-stdin" needs to be set.
[!] At least one of the arguments "--out-file", "--out-json" needs to be set.
[!] At least one of the arguments "--mode", "--mode-alt" needs to be set.
```

After — one line per unsatisfied group, no duplicate:

```
[!] At least one of the arguments "--from-file", "--from-stdin" needs to be set.
[!] At least one of the arguments "--out-file", "--out-json" needs to be set.
[!] At least one of the arguments "--mode", "--mode-alt" needs to be set.
```

Before, satisfying every group through the other member failed:

```
$ ./repro --mode-alt X --from-file a --out-file b
[!] Missing required argument "--mode"
exit=1
```

After, the same invocation succeeds with `exit=0`.

**Tests:** `go test ./...` passes across the module. Reverting only the new condition makes three of the four new tests fail, including the end-to-end one, confirming they cover the defect.

### Test Coverage

**Added:** `parser/required_in_exclusive_group_test.go`

- `TestRequiredInRequiredMutuallyExclusiveGroupNotUnconditionallyRequired` — a `required: true` member of a required exclusive group leaves `ap.requiredArguments` empty.
- `TestRequiredInNotRequiredMutuallyExclusiveGroupNotUnconditionallyRequired` — same for the not-required exclusive group type.
- `TestRequiredInDependentGroupStaysRequired` — a `required: true` member of a dependent group is still registered, pinning the limits of the change.
- `TestExclusiveGroupSatisfiedByOtherMemberParses` — end-to-end: `--mode-alt X` parses cleanly and sets the value. Run in a subprocess, following `parser/positional_error_test.go`, because `ParseFrom` calls `os.Exit` on error.

### Scope of Change

- **Files changed:** `parser/parse.go`, `parser/required_in_exclusive_group_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The `populateMaps` doc comment was updated to state the new condition.

### Risk and Rollout

Input that used to be rejected is now accepted, and one duplicate error line disappears. A tool that relied on a member of an exclusive group being individually mandatory would lose that enforcement — but that configuration is the defect being fixed, since it made the rest of the group unusable. Parsers without mutually exclusive groups are unaffected.

### Notes

The remaining one-line-per-group output is correct and is not changed here: "at least one of A, B, C, D" would be a weaker statement than "one of A, B and one of C, D". Making those lines distinguishable by naming their group is filed separately as #37, and the nondeterministic ordering of the lines as #36.
