### PR TITLE
Fix nondeterministic order of parsing error messages (Fixes #36)

### DIFF
--- a/parser/error_order_test.go
+++ b/parser/error_order_test.go
@@ -1,0 +1,147 @@
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRequiredArgumentsOrderIsStable verifies that populateMaps collects required arguments in a
+// stable order. Before the fix it ranged over the ap.Groups map, so the order of the names joined
+// into the "Missing required arguments" message changed between runs.
+//
+// populateMaps is called repeatedly: Go randomizes map iteration order on every range statement,
+// so a map based implementation would produce a wrong order within a few iterations.
+func TestRequiredArgumentsOrderIsStable(t *testing.T) {
+	var def, aOne, aTwo, bOne string
+	ap := NewParser("test")
+	ap.SetOptShowBannerOnRun(false)
+
+	if err := ap.NewStringArgument(&def, "-d", "--default-group-arg", "", true, "h"); err != nil {
+		t.Fatalf("NewStringArgument failed: %v", err)
+	}
+	// Registered in reverse alphabetical order to make sure the ordering comes from sorting
+	// the group names and not from the registration sequence.
+	groupB, err := ap.NewArgumentGroup("Bravo")
+	if err != nil {
+		t.Fatalf("NewArgumentGroup(Bravo) failed: %v", err)
+	}
+	if err := groupB.NewStringArgument(&bOne, "-b", "--bravo-one", "", true, "h"); err != nil {
+		t.Fatalf("group.NewStringArgument failed: %v", err)
+	}
+	groupA, err := ap.NewArgumentGroup("Alpha")
+	if err != nil {
+		t.Fatalf("NewArgumentGroup(Alpha) failed: %v", err)
+	}
+	if err := groupA.NewStringArgument(&aOne, "-1", "--alpha-one", "", true, "h"); err != nil {
+		t.Fatalf("group.NewStringArgument failed: %v", err)
+	}
+	if err := groupA.NewStringArgument(&aTwo, "-2", "--alpha-two", "", true, "h"); err != nil {
+		t.Fatalf("group.NewStringArgument failed: %v", err)
+	}
+
+	// The default group is keyed by "", which sorts before any named group.
+	expected := []string{"--default-group-arg", "--alpha-one", "--alpha-two", "--bravo-one"}
+
+	for i := 0; i < 50; i++ {
+		ap.populateMaps(&ap.ParsingState)
+
+		got := make([]string, 0, len(ap.requiredArguments))
+		for _, arg := range ap.requiredArguments {
+			got = append(got, arg.GetLongName())
+		}
+		if strings.Join(got, " ") != strings.Join(expected, " ") {
+			t.Fatalf("iteration %d: expected required arguments in order %v, got %v", i, expected, got)
+		}
+	}
+}
+
+// TestGroupErrorMessageOrderIsStable verifies that the group constraint errors are reported in
+// alphabetical group order rather than in map iteration order. The groups below are named "Source",
+// "Output" and "Mode", so their messages must come out as Mode, Output, Source, identified here by
+// the arguments each message names.
+//
+// ParseFrom prints the messages and calls os.Exit(1), so the parse runs in a subprocess and its
+// output is inspected from the parent.
+func TestGroupErrorMessageOrderIsStable(t *testing.T) {
+	if os.Getenv("GOOPTS_ERROR_ORDER_SUBPROCESS") == "1" {
+		var a1, a2, b1, b2, c1, c2 string
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+
+		source, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Source")
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := source.NewStringArgument(&a1, "-f", "--from-file", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+		if err := source.NewStringArgument(&a2, "-s", "--from-stdin", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+
+		output, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Output")
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := output.NewStringArgument(&b1, "-o", "--out-file", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+		if err := output.NewStringArgument(&b2, "-j", "--out-json", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+
+		mode, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Mode")
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := mode.NewStringArgument(&c1, "-m", "--mode", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+		if err := mode.NewStringArgument(&c2, "-M", "--mode-alt", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+
+		// Mirrors Parse(): raw arguments start with the program name and parsing starts at 1.
+		ap.ParsingState.SetRawArguments([]string{"test"})
+		ap.ParseFrom(1, &ap.ParsingState)
+		os.Exit(0)
+	}
+
+	// Each subprocess gets a fresh map iteration order, so a few runs are enough to catch
+	// an implementation that depends on it.
+	for run := 0; run < 5; run++ {
+		cmd := exec.Command(os.Args[0], "-test.run=TestGroupErrorMessageOrderIsStable")
+		cmd.Env = append(os.Environ(), "GOOPTS_ERROR_ORDER_SUBPROCESS=1")
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("run %d: expected the parser to report the unsatisfied groups and exit non-zero", run)
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			t.Fatalf("run %d: registering the argument groups failed", run)
+		}
+
+		got := []string{}
+		for _, line := range strings.Split(string(out), "\n") {
+			if !strings.HasPrefix(line, "[!] ") {
+				continue
+			}
+			switch {
+			case strings.Contains(line, "--mode"):
+				got = append(got, "Mode")
+			case strings.Contains(line, "--out-file"):
+				got = append(got, "Output")
+			case strings.Contains(line, "--from-file"):
+				got = append(got, "Source")
+			default:
+				t.Fatalf("run %d: unexpected error line: %s", run, line)
+			}
+		}
+
+		expected := "Mode Output Source"
+		if strings.Join(got, " ") != expected {
+			t.Fatalf("run %d: expected group errors in order %q, got %q", run, expected, strings.Join(got, " "))
+		}
+	}
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -11,6 +11,25 @@ import (
 	"github.com/TheManticoreProject/goopts/positionals"
 )
 
+// sortedGroupNames returns the names of all argument groups sorted alphabetically, including the
+// empty name of the default group.
+//
+// Iterating groups through this method instead of ranging over the `Groups` map keeps every output
+// derived from that iteration reproducible, since Go randomizes map iteration order. It also matches
+// the alphabetical group ordering used by the usage message.
+//
+// Returns:
+// - A slice of group names sorted alphabetically.
+func (ap *ArgumentsParser) sortedGroupNames() []string {
+	groupNames := make([]string, 0, len(ap.Groups))
+	for groupName := range ap.Groups {
+		groupNames = append(groupNames, groupName)
+	}
+	slices.Sort(groupNames)
+
+	return groupNames
+}
+
 // populateMaps initializes the maps that store the associations between short and long argument names
 // and their corresponding argument structures. This method is called to prepare the parser for argument
 // handling and validation.
@@ -48,8 +67,10 @@ func (ap *ArgumentsParser) populateMaps(parsingState *ParsingState) {
 		ap.Groups[""] = &argumentgroup.ArgumentGroup{}
 	}
 
-	// Register arguments from every group exactly once (the default group is keyed by "")
-	for _, group := range ap.Groups {
+	// Register arguments from every group exactly once (the default group is keyed by ""),
+	// in a stable order so that error messages built from these slices are reproducible
+	for _, groupName := range ap.sortedGroupNames() {
+		group := ap.Groups[groupName]
 		for _, arg := range group.Arguments {
 			if shortName := arg.GetShortName(); shortName != "" {
 				ap.shortNameToArgument[shortName] = arg
@@ -266,8 +287,10 @@ func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 			}
 		}
 
-		// Check if all required arguments in groups have been parsed
-		for _, group := range ap.Groups {
+		// Check if all required arguments in groups have been parsed, in a stable order so that
+		// the resulting error messages are always reported in the same sequence
+		for _, groupName := range ap.sortedGroupNames() {
+			group := ap.Groups[groupName]
 			argumentsPresent := []string{}
 			argumentsMissing := []string{}
 			for _, arg := range group.Arguments {


### PR DESCRIPTION
### Linked Issue

`Closes #36`

### Root Cause

Two loops drove user-visible output straight from Go map iteration order. `populateMaps` built `ap.requiredArguments` with `for _, group := range ap.Groups`, so the slice order — and therefore the order of names joined into the "Missing required arguments" message — was whatever order the runtime chose for that range statement. The group validation loop in `ParseFrom` ranged over the same map, so the sequence in which per-group constraint messages were appended to `parsingState.ErrorMessages` varied the same way.

Go deliberately randomizes map iteration order, so this was not merely unspecified but actively different from run to run. `UsageFrom` already sorted group names before printing, which left the usage block stable while the error lines printed underneath it were not.

### Fix Description

Added an unexported `sortedGroupNames` helper on `ArgumentsParser` that returns all group names — including the empty name of the default group — sorted alphabetically. Both loops now iterate those names and look the group up by key.

Sorting by group name, rather than by argument name, is what makes the errors line up with the usage output, which groups arguments under the same alphabetical section order. The default group sorts first because its key is the empty string, matching the usage layout where the default group is printed above the named groups.

`slices.Sort` is used because `slices` is already imported in `parse.go`; `usage.go` keeps its own inline `sort.Strings` block, since converting it is unrelated to this defect.

### How Verified

**Runtime.** A parser with a required argument in the default group and required arguments in two named groups, before the fix, over six runs:

```
run 1: [!] Missing required arguments "--domain", "--dc-ip", "--host", "--user", "--password"
run 2: [!] Missing required arguments "--host", "--user", "--password", "--domain", "--dc-ip"
run 6: [!] Missing required arguments "--domain", "--dc-ip", "--host", "--user", "--password"
```

After the fix, the same binary run six times produces byte-identical error output (compared by hashing the `[!]` lines — one distinct hash across six runs), ordered default group first, then groups alphabetically:

```
[!] Missing required arguments "--host", "--user", "--password", "--domain", "--dc-ip"
[!] At least one of the arguments "--kdc", "--no-kerberos" needs to be set.
```

A second parser with three required mutually exclusive groups, which previously reordered whole error lines between runs, likewise produces one distinct hash across six runs.

**Tests:** `go test ./...` passes, and the two new tests pass with `-count=10`. Reverting both loops to map iteration makes them fail on the first iteration of every one of 10 runs (20 failures out of 20 test executions).

### Test Coverage

**Added:** `parser/error_order_test.go`

- `TestRequiredArgumentsOrderIsStable` — registers required arguments in the default group and in groups "Bravo" and "Alpha", in reverse alphabetical order, then calls `populateMaps` 50 times and asserts `ap.requiredArguments` always comes out as default group, Alpha, Bravo. Repeated calls matter because Go randomizes each range statement, so a map based implementation fails within a few iterations.
- `TestGroupErrorMessageOrderIsStable` — three required mutually exclusive groups named "Source", "Output" and "Mode"; asserts the printed error lines always appear in alphabetical group order (Mode, Output, Source) across 5 subprocess runs, each of which gets a fresh map iteration order. Lines are identified by the argument names they contain rather than by exact string match, so the assertion survives later wording changes.

### Scope of Change

- **Files changed:** `parser/parse.go`, `parser/error_order_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Message wording and the set of messages are unchanged; only their order is now fixed.

### Risk and Rollout

No behavior changes beyond ordering, and the new order is the one the usage block already used. A caller that happened to depend on a particular random order could not have done so reliably.

### Notes

`sortedGroupNames` returns the default group's empty key along with named groups; both call sites need it, since required arguments and group constraints both apply to the default group.
