### PR TITLE
Name the argument group in group constraint errors (Closes #37)

### DIFF
--- a/parser/group_error_naming_test.go
+++ b/parser/group_error_naming_test.go
@@ -1,0 +1,121 @@
+package parser
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// runGroupErrorSubprocess re-executes the named test in a subprocess with the
+// GOOPTS_GROUP_NAMING_SUBPROCESS marker set, and returns the "[!] " error lines it printed.
+// ParseFrom prints its error messages and calls os.Exit(1), so they have to be collected from a
+// separate process.
+func runGroupErrorSubprocess(t *testing.T, testName string) []string {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run="+testName)
+	cmd.Env = append(os.Environ(), "GOOPTS_GROUP_NAMING_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatalf("expected the parser to report an unsatisfied group and exit non-zero")
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+		t.Fatalf("registering the argument group failed")
+	}
+
+	lines := []string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "[!] ") {
+			lines = append(lines, strings.TrimPrefix(line, "[!] "))
+		}
+	}
+
+	return lines
+}
+
+// TestGroupErrorMessageIsPrefixedWithGroupName verifies that a constraint error names the group it
+// came from, so that several groups produce distinguishable lines.
+func TestGroupErrorMessageIsPrefixedWithGroupName(t *testing.T) {
+	if os.Getenv("GOOPTS_GROUP_NAMING_SUBPROCESS") == "1" {
+		var a, b string
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+
+		grp, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("Source")
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&a, "-f", "--from-file", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&b, "-s", "--from-stdin", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+
+		ap.ParsingState.SetRawArguments([]string{"test"})
+		ap.ParseFrom(1, &ap.ParsingState)
+		os.Exit(0)
+	}
+
+	lines := runGroupErrorSubprocess(t, "TestGroupErrorMessageIsPrefixedWithGroupName")
+
+	expected := "Source: at least one of the arguments \"--from-file\", \"--from-stdin\" needs to be set."
+	if len(lines) != 1 || lines[0] != expected {
+		t.Fatalf("expected exactly one error line %q, got %v", expected, lines)
+	}
+}
+
+// TestGroupErrorMessageWithoutGroupNameIsCapitalized verifies that a constraint group with no name
+// keeps the unprefixed wording, with the message capitalized because it starts the line.
+func TestGroupErrorMessageWithoutGroupNameIsCapitalized(t *testing.T) {
+	if os.Getenv("GOOPTS_GROUP_NAMING_SUBPROCESS") == "1" {
+		var a, b string
+		ap := NewParser("test")
+		ap.SetOptShowBannerOnRun(false)
+
+		grp, err := ap.NewRequiredMutuallyExclusiveArgumentGroup("")
+		if err != nil {
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&a, "-f", "--from-file", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+		if err := grp.NewStringArgument(&b, "-s", "--from-stdin", "", false, "h"); err != nil {
+			os.Exit(2)
+		}
+
+		ap.ParsingState.SetRawArguments([]string{"test"})
+		ap.ParseFrom(1, &ap.ParsingState)
+		os.Exit(0)
+	}
+
+	lines := runGroupErrorSubprocess(t, "TestGroupErrorMessageWithoutGroupNameIsCapitalized")
+
+	expected := "At least one of the arguments \"--from-file\", \"--from-stdin\" needs to be set."
+	if len(lines) != 1 || lines[0] != expected {
+		t.Fatalf("expected exactly one error line %q, got %v", expected, lines)
+	}
+}
+
+// TestFormatGroupErrorMessage covers the message builder directly, including the empty message
+// guard, which the ParseFrom call sites never hit because they always pass a literal.
+func TestFormatGroupErrorMessage(t *testing.T) {
+	tests := []struct {
+		groupName string
+		message   string
+		expected  string
+	}{
+		{"Source", "at least one of the arguments \"--a\" needs to be set.", "Source: at least one of the arguments \"--a\" needs to be set."},
+		{"", "at least one of the arguments \"--a\" needs to be set.", "At least one of the arguments \"--a\" needs to be set."},
+		{"", "", ""},
+		{"Proxy", "", "Proxy: "},
+	}
+
+	for _, test := range tests {
+		if got := formatGroupErrorMessage(test.groupName, test.message); got != test.expected {
+			t.Fatalf("formatGroupErrorMessage(%q, %q) = %q, expected %q", test.groupName, test.message, got, test.expected)
+		}
+	}
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -11,6 +11,34 @@ import (
 	"github.com/TheManticoreProject/goopts/positionals"
 )
 
+// formatGroupErrorMessage builds the error message reported for an unsatisfied argument group
+// constraint, prefixed with the name of the group the constraint belongs to.
+//
+// A parser can declare several constraint groups, each producing a message of the same shape, so
+// naming the group is what makes those lines distinguishable and lets them be matched with the
+// named sections of the usage message.
+//
+// Parameters:
+//   - groupName: The name of the argument group the constraint belongs to. It is empty for the
+//     default group.
+//   - message: The constraint message, written in lower case so it reads correctly after the
+//     group name.
+//
+// Returns:
+//   - The message prefixed with the group name, or the message alone with its first letter
+//     capitalized when the group has no name.
+func formatGroupErrorMessage(groupName, message string) string {
+	if len(groupName) == 0 {
+		if len(message) == 0 {
+			return message
+		}
+
+		return strings.ToUpper(message[:1]) + message[1:]
+	}
+
+	return fmt.Sprintf("%s: %s", groupName, message)
+}
+
 // populateMaps initializes the maps that store the associations between short and long argument names
 // and their corresponding argument structures. This method is called to prepare the parser for argument
 // handling and validation.
@@ -282,25 +310,25 @@ func (ap *ArgumentsParser) ParseFrom(index int, parsingState *ParsingState) {
 				// One needs to be set, and one only
 				if len(argumentsPresent) == 0 {
 					if len(argumentsMissing) == 1 {
-						parsingState.AddErrorMessage(fmt.Sprintf("The argument \"%s\" needs to be set.", argumentsMissing[0]))
+						parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("the argument \"%s\" needs to be set.", argumentsMissing[0])))
 					} else if len(argumentsMissing) > 1 {
-						parsingState.AddErrorMessage(fmt.Sprintf("At least one of the arguments \"%s\" needs to be set.", strings.Join(argumentsMissing, "\", \"")))
+						parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("at least one of the arguments \"%s\" needs to be set.", strings.Join(argumentsMissing, "\", \""))))
 					}
 				} else if len(argumentsPresent) > 1 {
-					parsingState.AddErrorMessage(fmt.Sprintf("Arguments \"%s\" cannot be set together.", strings.Join(argumentsPresent, "\", \"")))
+					parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("arguments \"%s\" cannot be set together.", strings.Join(argumentsPresent, "\", \""))))
 				}
 			} else if group.Type == argumentgroup.ARGUMENT_GROUP_TYPE_NOT_REQUIRED_MUTUALLY_EXCLUSIVE {
 				// None can be set but if one is set then only one has to be set
 				if len(argumentsPresent) > 1 {
-					parsingState.AddErrorMessage(fmt.Sprintf("Arguments \"%s\" cannot be set together.", strings.Join(argumentsPresent, "\", \"")))
+					parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("arguments \"%s\" cannot be set together.", strings.Join(argumentsPresent, "\", \""))))
 				}
 			} else if group.Type == argumentgroup.ARGUMENT_GROUP_TYPE_DEPENDENT {
 				// If one is set, all need to be set
 				if len(argumentsMissing) != 0 {
 					if len(argumentsPresent) > 1 {
-						parsingState.AddErrorMessage(fmt.Sprintf("When arguments \"%s\" are set, \"%s\" need to be set too.", strings.Join(argumentsPresent, "\", \""), strings.Join(argumentsMissing, "\", \"")))
+						parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("when arguments \"%s\" are set, \"%s\" need to be set too.", strings.Join(argumentsPresent, "\", \""), strings.Join(argumentsMissing, "\", \""))))
 					} else if len(argumentsPresent) == 1 {
-						parsingState.AddErrorMessage(fmt.Sprintf("When argument \"%s\" is set, \"%s\" need to be set too.", argumentsPresent[0], strings.Join(argumentsMissing, "\", \"")))
+						parsingState.AddErrorMessage(formatGroupErrorMessage(group.Name, fmt.Sprintf("when argument \"%s\" is set, \"%s\" need to be set too.", argumentsPresent[0], strings.Join(argumentsMissing, "\", \""))))
 					}
 				}
 			}


### PR DESCRIPTION
### Linked Issue

`Closes #37`

### Motivation

`ArgumentGroup` carries a `Name`, and `UsageFrom` prints each group under that name, but the group validation loop in `ParseFrom` never used it. A parser with several constraint groups therefore printed a run of near-identical lines with nothing to tell them apart:

```
[!] At least one of the arguments "--from-file", "--from-stdin" needs to be set.
[!] At least one of the arguments "--out-file", "--out-json" needs to be set.
[!] At least one of the arguments "--mode", "--mode-alt" needs to be set.
```

Reading that as three separate constraints, and finding the matching section in the usage block above, is left entirely to the user.

Merging the lines into one was considered and rejected: "at least one of A, B, C, D" is a weaker statement than "one of A, B and one of C, D", so a combined line would misdescribe the constraints. Naming the group keeps one line per constraint while making each line identifiable.

### Change Description

All six group constraint messages are now built through a new `formatGroupErrorMessage(groupName, message)` helper that prefixes the message with the group name. The message literals were rewritten in lower case so they read correctly after the prefix.

A constraint group can have an empty name — `NewRequiredMutuallyExclusiveArgumentGroup("")` is accepted and stores the group under the default group's key — so the helper handles that case by returning the message alone with its first letter capitalized, preserving today's wording exactly for those groups.

Only the six messages emitted by the group validation loop change. Missing required arguments, missing and extra positional arguments, unknown arguments, value parse errors and the subparser message are untouched.

### How Verified

**Runtime**, three required mutually exclusive groups plus a dependent group.

Before:

```
[!] At least one of the arguments "--out-file", "--out-json" needs to be set.
[!] At least one of the arguments "--mode", "--mode-alt" needs to be set.
[!] At least one of the arguments "--from-file", "--from-stdin" needs to be set.
```

After:

```
[!] Output: at least one of the arguments "--out-file", "--out-json" needs to be set.
[!] Mode: at least one of the arguments "--mode", "--mode-alt" needs to be set.
[!] Source: at least one of the arguments "--from-file", "--from-stdin" needs to be set.
```

The other two group rules were exercised in the same run by setting two members of one group and one member of the dependent group:

```
[!] Source: arguments "--from-file", "--from-stdin" cannot be set together.
[!] Proxy: when argument "--proxy-host" is set, "--proxy-port" need to be set too.
```

**Tests:** `go test ./...` passes across the module, including the pre-existing group tests, which assert on group registration rather than message text.

### Test Coverage

**Added:** `parser/group_error_naming_test.go`

- `TestGroupErrorMessageIsPrefixedWithGroupName` — asserts the exact line `Source: at least one of the arguments "--from-file", "--from-stdin" needs to be set.`, captured from a subprocess since `ParseFrom` prints and exits.
- `TestGroupErrorMessageWithoutGroupNameIsCapitalized` — a constraint group with an empty name still yields `At least one of the arguments ... needs to be set.`
- `TestFormatGroupErrorMessage` — table test over the helper, including both empty-input edge cases.

### Scope of Change

- **Files changed:** `parser/parse.go`, `parser/group_error_naming_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the message text:** none. No control flow, no change to which constraints are checked or when an error is recorded.

### Risk and Rollout

This changes user-visible error text for every goopts-based tool that uses named constraint groups. Anything matching those messages verbatim — scripted output checks, documentation examples — needs updating. No parsing behavior changes, so there is no functional risk beyond the wording.

### Notes

Ordering of these lines is addressed separately in #36 / PR #39, and the duplicate `Missing required argument` line visible in the "before" output of a group with a `required: true` member in #35 / PR #38.
